### PR TITLE
Добавляет переключение активности подразделений

### DIFF
--- a/backend/DirectoryService/src/DirectoryService.Application/Departments/Commands/ChangeDepartmentActivity/ChangeDepartmentActivityCommand.cs
+++ b/backend/DirectoryService/src/DirectoryService.Application/Departments/Commands/ChangeDepartmentActivity/ChangeDepartmentActivityCommand.cs
@@ -1,0 +1,5 @@
+﻿using SharedService.Core.Abstractions;
+
+namespace DirectoryService.Application.Departments.Commands.ChangeDepartmentActivity;
+
+public record ChangeDepartmentActivityCommand(Guid DepartmentId, bool IsActive) : ICommand;

--- a/backend/DirectoryService/src/DirectoryService.Application/Departments/Commands/ChangeDepartmentActivity/ChangeDepartmentActivityHandler.cs
+++ b/backend/DirectoryService/src/DirectoryService.Application/Departments/Commands/ChangeDepartmentActivity/ChangeDepartmentActivityHandler.cs
@@ -1,0 +1,111 @@
+﻿using CSharpFunctionalExtensions;
+using DirectoryService.Application.Constants;
+using DirectoryService.Domain.Departments;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Logging;
+using SharedService.Core.Abstractions;
+using SharedService.Core.Database;
+using SharedService.SharedKernel;
+
+namespace DirectoryService.Application.Departments.Commands.ChangeDepartmentActivity;
+
+public class ChangeDepartmentActivityHandler : ICommandHandler<Guid, ChangeDepartmentActivityCommand>
+{
+    private readonly IDepartmentsRepository _departmentsRepository;
+    private readonly HybridCache _cache;
+    private readonly ITransactionManager _transactionManager;
+    private readonly ILogger<ChangeDepartmentActivityHandler> _logger;
+
+    public ChangeDepartmentActivityHandler(
+        IDepartmentsRepository departmentsRepository,
+        HybridCache cache,
+        ITransactionManager transactionManager,
+        ILogger<ChangeDepartmentActivityHandler> logger)
+    {
+        _departmentsRepository = departmentsRepository;
+        _cache = cache;
+        _transactionManager = transactionManager;
+        _logger = logger;
+    }
+
+    public async Task<Result<Guid, Errors>> Handle(
+        ChangeDepartmentActivityCommand command, CancellationToken cancellationToken)
+    {
+        var departmentId = DepartmentId.Create(command.DepartmentId);
+
+        var transactionResult = await _transactionManager.BeginTransactionAsync(cancellationToken);
+        if (transactionResult.IsFailure)
+        {
+            return transactionResult.Error.ToErrors();
+        }
+
+        using var transaction = transactionResult.Value;
+
+        var departmentResult = await _departmentsRepository.GetByIdWithLock(departmentId, cancellationToken);
+        if (departmentResult.IsFailure)
+        {
+            transaction.Rollback();
+            return departmentResult.Error.ToErrors();
+        }
+
+        var department = departmentResult.Value;
+
+        if (department.DeletedAt != null)
+        {
+            transaction.Rollback();
+            return DepartmentErrors.ArchivedActivityCannotBeChanged().ToErrors();
+        }
+
+        if (!command.IsActive && department.IsActive &&
+            await _departmentsRepository.HasActiveDescendants(department.Path, cancellationToken))
+        {
+            transaction.Rollback();
+            return DepartmentErrors.ActiveDescendantsPreventDeactivation().ToErrors();
+        }
+
+        if (command.IsActive && department is { IsActive: false, ParentId: not null })
+        {
+            var parentResult = await _departmentsRepository.GetByIdWithLock(department.ParentId, cancellationToken);
+            if (parentResult.IsFailure)
+            {
+                transaction.Rollback();
+                return DepartmentErrors.InactiveParentPreventsActivation().ToErrors();
+            }
+
+            var parent = parentResult.Value;
+            if (!parent.IsActive || parent.DeletedAt is not null)
+            {
+                transaction.Rollback();
+                return DepartmentErrors.InactiveParentPreventsActivation().ToErrors();
+            }
+        }
+
+        if (department.IsActive == command.IsActive)
+        {
+            return department.Id.Value;
+        }
+
+        department.SetActivity(command.IsActive);
+
+        var saveChangeResult = await _transactionManager.SaveChangeAsync(cancellationToken);
+        if (saveChangeResult.IsFailure)
+        {
+            transaction.Rollback();
+            return saveChangeResult.Error.ToErrors();
+        }
+
+        var commitResult = transaction.Commit();
+
+        if (commitResult.IsFailure)
+        {
+            transaction.Rollback();
+            return commitResult.Error.ToErrors();
+        }
+
+        await _cache.RemoveByTagAsync(CacheKeys.DEPARTMENT_KEY, cancellationToken);
+
+        _logger.LogInformation("Department {DepartmentId} change status active successfully.", department.Id.Value);
+
+        return department.Id.Value;
+    }
+}

--- a/backend/DirectoryService/src/DirectoryService.Application/Departments/Commands/CreateDepartments/CreateDepartmentHandler.cs
+++ b/backend/DirectoryService/src/DirectoryService.Application/Departments/Commands/CreateDepartments/CreateDepartmentHandler.cs
@@ -9,6 +9,7 @@ using FluentValidation;
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Logging;
 using SharedService.Core.Abstractions;
+using SharedService.Core.Database;
 using SharedService.Core.Validation;
 using SharedService.SharedKernel;
 
@@ -20,19 +21,23 @@ public class CreateDepartmentHandler : ICommandHandler<Guid, CreateDepartmentCom
     private readonly IDepartmentsRepository _departmentsRepository;
     private readonly ILocationsRepository _locationsRepository;
     private readonly ILogger<CreateDepartmentHandler> _logger;
+    private readonly ITransactionManager _transactionManager;
     private readonly IValidator<CreateDepartmentRequest> _validator;
 
     public CreateDepartmentHandler(
         ILocationsRepository locationsRepository,
         IDepartmentsRepository departmentsRepository,
         IValidator<CreateDepartmentRequest> validator,
-        ILogger<CreateDepartmentHandler> logger, HybridCache cache)
+        ILogger<CreateDepartmentHandler> logger,
+        HybridCache cache,
+        ITransactionManager transactionManager)
     {
         _validator = validator;
         _locationsRepository = locationsRepository;
         _departmentsRepository = departmentsRepository;
         _logger = logger;
         _cache = cache;
+        _transactionManager = transactionManager;
     }
 
     public async Task<Result<Guid, Errors>> Handle(
@@ -60,6 +65,14 @@ public class CreateDepartmentHandler : ICommandHandler<Guid, CreateDepartmentCom
             return checkExistingIdsResult.Error;
         }
 
+        var transactionResult = await _transactionManager.BeginTransactionAsync(cancellationToken);
+        if (transactionResult.IsFailure)
+        {
+            return transactionResult.Error.ToErrors();
+        }
+
+        using var transaction = transactionResult.Value;
+
         var locationIds =
             command.Request.LocationIds.Select(l => new DepartmentLocation(
                     DepartmentLocationId.CreateNew(), departmentId, LocationId.Create(l)))
@@ -82,10 +95,17 @@ public class CreateDepartmentHandler : ICommandHandler<Guid, CreateDepartmentCom
             var parentDepartmentId = DepartmentId.Create(parentId.Value);
 
             var getParentDepartmentResult =
-                await _departmentsRepository.GetByIdAsync(parentDepartmentId, cancellationToken);
+                await _departmentsRepository.GetByIdWithLock(parentDepartmentId, cancellationToken);
             if (getParentDepartmentResult.IsFailure)
             {
+                transaction.Rollback();
                 return getParentDepartmentResult.Error.ToErrors();
+            }
+
+            if (!getParentDepartmentResult.Value.IsActive || getParentDepartmentResult.Value.DeletedAt is not null)
+            {
+                transaction.Rollback();
+                return GeneralErrors.NotFound("department", parentDepartmentId.Value).ToErrors();
             }
 
             var childParentDepartmentResult = Department.CreateChild(
@@ -101,8 +121,16 @@ public class CreateDepartmentHandler : ICommandHandler<Guid, CreateDepartmentCom
         var repositoryResult = await _departmentsRepository.AddAsync(department, cancellationToken);
         if (repositoryResult.IsFailure)
         {
+            transaction.Rollback();
             return Error.Failure(null, repositoryResult.Error.Message)
                 .ToErrors();
+        }
+
+        var commitResult = transaction.Commit();
+        if (commitResult.IsFailure)
+        {
+            transaction.Rollback();
+            return commitResult.Error.ToErrors();
         }
 
         await _cache.RemoveByTagAsync(CacheKeys.DEPARTMENT_KEY, cancellationToken);

--- a/backend/DirectoryService/src/DirectoryService.Application/Departments/Commands/RestoreDepartments/RestoreDepartmentHandler.cs
+++ b/backend/DirectoryService/src/DirectoryService.Application/Departments/Commands/RestoreDepartments/RestoreDepartmentHandler.cs
@@ -70,6 +70,12 @@ public class RestoreDepartmentHandler : ICommandHandler<Guid, RestoreDepartmentC
             return department.Id.Value;
         }
 
+        if (department.DeletedAt is null)
+        {
+            transaction.Rollback();
+            return DepartmentErrors.DepartmentIsNotArchived().ToErrors();
+        }
+
         await _departmentsRepository.LockDescendants(department.Path, cancellationToken);
 
         Path restoredPath;

--- a/backend/DirectoryService/src/DirectoryService.Application/Departments/Commands/SoftDeleteDepartments/SoftDeleteDepartmentHandler.cs
+++ b/backend/DirectoryService/src/DirectoryService.Application/Departments/Commands/SoftDeleteDepartments/SoftDeleteDepartmentHandler.cs
@@ -61,8 +61,7 @@ public class SoftDeleteDepartmentHandler : ICommandHandler<Guid, SoftDeleteDepar
 
         using var transaction = transactionResult.Value;
 
-        var departmentResult = await _departmentsRepository.GetBy(
-            d => d.Id == departmentId && d.IsActive == true, cancellationToken);
+        var departmentResult = await _departmentsRepository.GetByIdWithLock(departmentId, cancellationToken);
         if (departmentResult.IsFailure)
         {
             transaction.Rollback();
@@ -70,6 +69,12 @@ public class SoftDeleteDepartmentHandler : ICommandHandler<Guid, SoftDeleteDepar
         }
 
         var department = departmentResult.Value;
+
+        if (department.DeletedAt is not null)
+        {
+            transaction.Rollback();
+            return GeneralErrors.NotFound("department", departmentId.Value).ToErrors();
+        }
 
         department.MarkAsDelete();
 

--- a/backend/DirectoryService/src/DirectoryService.Application/Departments/DepartmentErrors.cs
+++ b/backend/DirectoryService/src/DirectoryService.Application/Departments/DepartmentErrors.cs
@@ -28,6 +28,14 @@ public static class DepartmentErrors
             "departmentId");
     }
 
+    public static Error DepartmentIsNotArchived()
+    {
+        return Error.Conflict(
+            "department.restore.not_archived",
+            "Подразделение не находится в архиве.",
+            "departmentId");
+    }
+
     public static Error ParentIsArchived()
     {
         return Error.Conflict(

--- a/backend/DirectoryService/src/DirectoryService.Application/Departments/DepartmentErrors.cs
+++ b/backend/DirectoryService/src/DirectoryService.Application/Departments/DepartmentErrors.cs
@@ -4,6 +4,30 @@ namespace DirectoryService.Application.Departments;
 
 public static class DepartmentErrors
 {
+    public static Error ArchivedActivityCannotBeChanged()
+    {
+        return Error.Conflict(
+            "department.activity.archived",
+            "Нельзя изменить активность подразделения, находящегося в архиве.",
+            "departmentId");
+    }
+
+    public static Error ActiveDescendantsPreventDeactivation()
+    {
+        return Error.Conflict(
+            "department.activity.active_descendants",
+            "Нельзя деактивировать подразделение, пока у него есть активные дочерние подразделения.",
+            "departmentId");
+    }
+
+    public static Error InactiveParentPreventsActivation()
+    {
+        return Error.Conflict(
+            "department.activity.inactive_parent",
+            "Сначала активируйте родительское подразделение.",
+            "departmentId");
+    }
+
     public static Error ParentIsArchived()
     {
         return Error.Conflict(

--- a/backend/DirectoryService/src/DirectoryService.Application/Departments/IDepartmentsRepository.cs
+++ b/backend/DirectoryService/src/DirectoryService.Application/Departments/IDepartmentsRepository.cs
@@ -23,6 +23,8 @@ public interface IDepartmentsRepository
 
     Task LockDescendants(Path path, CancellationToken cancellationToken = default);
 
+    Task<bool> HasActiveDescendants(Path path, CancellationToken cancellationToken = default);
+
     Task<UnitResult<Error>> MoveDepartments(
         Path parentPath,
         Path departmentPath,

--- a/backend/DirectoryService/src/DirectoryService.Application/Departments/Queries/GetDepartmentChildren/GetDepartmentChildrenHandler.cs
+++ b/backend/DirectoryService/src/DirectoryService.Application/Departments/Queries/GetDepartmentChildren/GetDepartmentChildrenHandler.cs
@@ -46,6 +46,7 @@ public class GetDepartmentChildrenHandler
     {
         string key = CacheKeys.CreateDepartmentsKey(
             "parentId", query.ParentId.ToString(),
+            "onlyActive", query.Request.OnlyActive.ToString(),
             "page", query.Request.Page.ToString(),
             "pageSize", query.Request.PageSize.ToString());
 
@@ -67,29 +68,31 @@ public class GetDepartmentChildrenHandler
         GetDepartmentChildrenQuery query)
     {
         const string sql = """
-                           SELECT d.id,
-                                  d.parent_id,
-                                  d.name,
-                                  d.identifier,
-                                  d.depth,
-                                  d.path,
-                                  d.is_active,
-                                  d.created_at,
-                                  d.updated_at,
-                                  d.deleted_at,
+                      SELECT d.id,
+                             d.parent_id,
+                             d.name,
+                             d.identifier,
+                             d.depth,
+                             d.path,
+                             d.is_active,
+                             d.created_at,
+                             d.updated_at,
+                             d.deleted_at,
 
-                                  (EXISTS(SELECT 1
-                                          FROM departments child
-                                          WHERE parent_id = d.id 
-                                            AND child.is_active = true)) AS has_more_children,
+                             (EXISTS(SELECT 1
+                                     FROM departments child
+                                     WHERE parent_id = d.id
+                                       AND child.deleted_at IS NULL
+                                       AND (@OnlyActive = FALSE OR child.is_active = TRUE))) AS has_more_children,
 
-                                  COUNT(*) OVER ()                 AS total_count
-                           FROM departments d
-                           WHERE d.parent_id = @ParentId
-                             AND d.is_active = true
-                           ORDER BY d.created_at, d.id
-                           LIMIT @ChildSize OFFSET @ChildPage
-                           """;
+                             COUNT(*) OVER ()                 AS total_count
+                      FROM departments d
+                      WHERE d.parent_id = @ParentId
+                        AND d.deleted_at IS NULL
+                        AND (@OnlyActive = FALSE OR d.is_active = TRUE)
+                      ORDER BY d.created_at, d.id
+                      LIMIT @ChildSize OFFSET @ChildPage
+                      """;
 
         var dbConnection = _dbConnectionFactory.GetDbConnection();
 
@@ -111,6 +114,7 @@ public class GetDepartmentChildrenHandler
                 new
                 {
                     ParentId = query.ParentId,
+                    query.Request.OnlyActive,
                     ChildSize = query.Request.PageSize,
                     ChildPage = (query.Request.Page - 1) * query.Request.PageSize,
                 })).ToList();

--- a/backend/DirectoryService/src/DirectoryService.Application/Departments/Queries/GetDepartmentTreeRoots/GetDepartmentTreeRootsHandler.cs
+++ b/backend/DirectoryService/src/DirectoryService.Application/Departments/Queries/GetDepartmentTreeRoots/GetDepartmentTreeRootsHandler.cs
@@ -48,6 +48,7 @@ public class
     {
         string key = CacheKeys.CreateDepartmentsKey(
             "prefetch", query.Request.Prefetch.ToString(),
+            "onlyActive", query.Request.OnlyActive.ToString(),
             "page", query.Request.Page.ToString(),
             "pageSize", query.Request.PageSize.ToString());
 
@@ -69,75 +70,79 @@ public class
         GetDepartmentTreeRootsQuery query)
     {
         const string sql = """
-                           WITH roots AS (SELECT d.id,
-                                                 d.parent_id,
-                                                 d.name,
-                                                 d.identifier,
-                                                 d.depth,
-                                                 d.path,
-                                                 d.is_active,
-                                                 d.created_at,
-                                                 d.updated_at,
-                                                 COUNT(*) OVER () AS total_count
-                                          FROM departments d
-                                          WHERE d.parent_id IS NULL 
-                                                AND d.is_active = true
-                                          ORDER BY d.created_at
-                                          LIMIT @RootSize OFFSET @RootPage),
+                      WITH roots AS (SELECT d.id,
+                                            d.parent_id,
+                                            d.name,
+                                            d.identifier,
+                                            d.depth,
+                                            d.path,
+                                            d.is_active,
+                                            d.created_at,
+                                            d.updated_at,
+                                            COUNT(*) OVER () AS total_count
+                                     FROM departments d
+                                     WHERE d.parent_id IS NULL
+                                       AND d.deleted_at IS NULL
+                                       AND (@OnlyActive = FALSE OR d.is_active = TRUE)
+                                     ORDER BY d.created_at
+                                     LIMIT @RootSize OFFSET @RootPage),
 
-                                ranked_children AS (SELECT d.id,
-                                                           d.parent_id,
-                                                           d.name,
-                                                           d.identifier,
-                                                           d.depth,
-                                                           d.path,
-                                                           d.is_active,
-                                                           d.created_at,
-                                                           d.updated_at,
-                                                           ROW_NUMBER() OVER (PARTITION BY d.parent_id ORDER BY d.created_at) AS child_rank,
-                                                           COUNT(*) OVER ()                                                   AS total_count
-                                                    FROM departments d
-                                                             JOIN roots r ON d.parent_id = r.id
-                                                    WHERE d.is_active = true)
+                           ranked_children AS (SELECT d.id,
+                                                      d.parent_id,
+                                                      d.name,
+                                                      d.identifier,
+                                                      d.depth,
+                                                      d.path,
+                                                      d.is_active,
+                                                      d.created_at,
+                                                      d.updated_at,
+                                                      ROW_NUMBER() OVER (PARTITION BY d.parent_id ORDER BY d.created_at) AS child_rank,
+                                                      COUNT(*) OVER ()                                                   AS total_count
+                                               FROM departments d
+                                                        JOIN roots r ON d.parent_id = r.id
+                                               WHERE d.deleted_at IS NULL
+                                                 AND (@OnlyActive = FALSE OR d.is_active = TRUE))
 
-                           SELECT r.id,
-                                  r.parent_id,
-                                  r.name,
-                                  r.identifier,
-                                  r.depth,
-                                  r.path,
-                                  r.is_active,
-                                  r.created_at,
-                                  r.updated_at,
-                                  r.total_count,
+                      SELECT r.id,
+                             r.parent_id,
+                             r.name,
+                             r.identifier,
+                             r.depth,
+                             r.path,
+                             r.is_active,
+                             r.created_at,
+                             r.updated_at,
+                             r.total_count,
 
-                                  (EXISTS(SELECT 1
-                                          FROM departments d
-                                          WHERE d.parent_id = r.id 
-                                            AND d.is_active = true)) AS has_more_children
-                           FROM roots r
+                             (EXISTS(SELECT 1
+                                     FROM departments d
+                                     WHERE d.parent_id = r.id
+                                       AND d.deleted_at IS NULL
+                                       AND (@OnlyActive = FALSE OR d.is_active = TRUE))) AS has_more_children
+                      FROM roots r
 
-                           UNION ALL
+                      UNION ALL
 
-                           SELECT rc.id,
-                                  rc.parent_id,
-                                  rc.name,
-                                  rc.identifier,
-                                  rc.depth,
-                                  rc.path,
-                                  rc.is_active,
-                                  rc.created_at,
-                                  rc.updated_at,
-                                  rc.total_count,
+                      SELECT rc.id,
+                             rc.parent_id,
+                             rc.name,
+                             rc.identifier,
+                             rc.depth,
+                             rc.path,
+                             rc.is_active,
+                             rc.created_at,
+                             rc.updated_at,
+                             rc.total_count,
 
-                                  (EXISTS(SELECT 1
-                                          FROM departments d
-                                          WHERE d.parent_id = rc.id 
-                                            AND d.is_active = true)) AS has_more_children
+                             (EXISTS(SELECT 1
+                                     FROM departments d
+                                     WHERE d.parent_id = rc.id
+                                       AND d.deleted_at IS NULL
+                                       AND (@OnlyActive = FALSE OR d.is_active = TRUE))) AS has_more_children
 
-                           FROM ranked_children rc
-                           WHERE rc.child_rank <= @Prefetch
-                           """;
+                      FROM ranked_children rc
+                      WHERE rc.child_rank <= @Prefetch;
+                      """;
 
         var dbConnection = _dbConnectionFactory.GetDbConnection();
 
@@ -157,6 +162,7 @@ public class
                 },
                 param: new
                 {
+                    query.Request.OnlyActive,
                     RootSize = query.Request.PageSize,
                     RootPage = (query.Request.Page - 1) * query.Request.PageSize,
                     Prefetch = query.Request.Prefetch,

--- a/backend/DirectoryService/src/DirectoryService.Application/Departments/Queries/GetDepartments/GetDepartmentsHandler.cs
+++ b/backend/DirectoryService/src/DirectoryService.Application/Departments/Queries/GetDepartments/GetDepartmentsHandler.cs
@@ -52,6 +52,11 @@ public class GetDepartmentsHandler : IQueryHandler<PaginationEnvelope<Department
             conditions.Add("d.is_active = @isActive");
         }
 
+        if (request.IsArchived.HasValue)
+        {
+            conditions.Add(request.IsArchived.Value ? "d.deleted_at IS NOT NULL" : "d.deleted_at IS NULL");
+        }
+
         if (request.ParentId.HasValue)
         {
             parameters.Add("parentId", request.ParentId, DbType.Guid);

--- a/backend/DirectoryService/src/DirectoryService.Contracts/Departments/ChangeActivity/ChangeDepartmentActivityRequest.cs
+++ b/backend/DirectoryService/src/DirectoryService.Contracts/Departments/ChangeActivity/ChangeDepartmentActivityRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace DirectoryService.Contracts.Departments.ChangeActivity;
+
+public record ChangeDepartmentActivityRequest(bool IsActive);

--- a/backend/DirectoryService/src/DirectoryService.Contracts/Departments/GetDepartments/Requests/GetDepartmentChildrenRequest.cs
+++ b/backend/DirectoryService/src/DirectoryService.Contracts/Departments/GetDepartments/Requests/GetDepartmentChildrenRequest.cs
@@ -1,3 +1,3 @@
 ﻿namespace DirectoryService.Contracts.Departments.GetDepartments.Requests;
 
-public record GetDepartmentChildrenRequest() : PaginationRequest;
+public record GetDepartmentChildrenRequest(bool OnlyActive = false) : PaginationRequest;

--- a/backend/DirectoryService/src/DirectoryService.Contracts/Departments/GetDepartments/Requests/GetDepartmentTreeRootsRequest.cs
+++ b/backend/DirectoryService/src/DirectoryService.Contracts/Departments/GetDepartments/Requests/GetDepartmentTreeRootsRequest.cs
@@ -1,3 +1,3 @@
 ﻿namespace DirectoryService.Contracts.Departments.GetDepartments.Requests;
 
-public record GetDepartmentTreeRootsRequest(int Prefetch = 3) : PaginationRequest;
+public record GetDepartmentTreeRootsRequest(int Prefetch = 3, bool OnlyActive = false) : PaginationRequest;

--- a/backend/DirectoryService/src/DirectoryService.Contracts/Departments/GetDepartments/Requests/GetDepartmentsRequest.cs
+++ b/backend/DirectoryService/src/DirectoryService.Contracts/Departments/GetDepartments/Requests/GetDepartmentsRequest.cs
@@ -4,6 +4,7 @@ public record GetDepartmentsRequest(
     Guid[]? LocationIds,
     string? Search,
     bool? IsActive,
+    bool? IsArchived,
     Guid? ParentId,
     bool? IsParent,
     string? SortBy,

--- a/backend/DirectoryService/src/DirectoryService.Domain/Departments/Department.cs
+++ b/backend/DirectoryService/src/DirectoryService.Domain/Departments/Department.cs
@@ -200,6 +200,12 @@ public sealed class Department : BaseEntity<DepartmentId>, ISoftDeletable
         return UnitResult.Success<Error>();
     }
 
+    public void SetActivity(bool isActive)
+    {
+        IsActive = isActive;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
     public void Restore()
     {
         IsActive = true;

--- a/backend/DirectoryService/src/DirectoryService.Domain/Departments/Identifier.cs
+++ b/backend/DirectoryService/src/DirectoryService.Domain/Departments/Identifier.cs
@@ -7,6 +7,8 @@ namespace DirectoryService.Domain.Departments;
 
 public sealed record Identifier
 {
+    private const string ARCHIVED_PATH_PREFIX = "delete-";
+
     private static readonly Regex _identifierRegex =
         new("^[A-Za-z-]+$", RegexOptions.Compiled);
 
@@ -25,6 +27,11 @@ public sealed record Identifier
         }
 
         if (!_identifierRegex.IsMatch(value))
+        {
+            return GeneralErrors.MismatchRegex("department.identifier");
+        }
+
+        if (value.StartsWith(ARCHIVED_PATH_PREFIX, StringComparison.Ordinal))
         {
             return GeneralErrors.MismatchRegex("department.identifier");
         }

--- a/backend/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Departments/DepartmentsRepository.cs
+++ b/backend/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Departments/DepartmentsRepository.cs
@@ -158,7 +158,8 @@ public class DepartmentsRepository : IDepartmentsRepository
                                WHERE path <@ @parentPath::ltree
                                  AND path <> @parentPath::ltree
                                  AND deleted_at IS NULL
-                                 AND is_active = TRUE)
+                                 AND is_active = TRUE
+                                 AND NOT path ~ '*.delete-*.*'::lquery)
                            """;
 
         var command = new CommandDefinition(

--- a/backend/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Departments/DepartmentsRepository.cs
+++ b/backend/DirectoryService/src/DirectoryService.Infrastructure.Postgres/Departments/DepartmentsRepository.cs
@@ -149,6 +149,26 @@ public class DepartmentsRepository : IDepartmentsRepository
         await dbConnection.QueryAsync(sql, sqlParams);
     }
 
+    public async Task<bool> HasActiveDescendants(Path path, CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+                           SELECT EXISTS(
+                               SELECT 1
+                               FROM departments
+                               WHERE path <@ @parentPath::ltree
+                                 AND path <> @parentPath::ltree
+                                 AND deleted_at IS NULL
+                                 AND is_active = TRUE)
+                           """;
+
+        var command = new CommandDefinition(
+            sql,
+            new { parentPath = path.Value },
+            cancellationToken: cancellationToken);
+
+        return await _dbContext.Database.GetDbConnection().QuerySingleAsync<bool>(command);
+    }
+
     public async Task<UnitResult<Error>> MoveDepartments(
         Path parentPath,
         Path departmentPath,

--- a/backend/DirectoryService/src/DirectoryService.Presentation/Departments/DepartmentsController.cs
+++ b/backend/DirectoryService/src/DirectoryService.Presentation/Departments/DepartmentsController.cs
@@ -1,4 +1,5 @@
-﻿using DirectoryService.Application.Departments.Commands.CreateDepartments;
+﻿using DirectoryService.Application.Departments.Commands.ChangeDepartmentActivity;
+using DirectoryService.Application.Departments.Commands.CreateDepartments;
 using DirectoryService.Application.Departments.Commands.MoveDepartments;
 using DirectoryService.Application.Departments.Commands.RestoreDepartments;
 using DirectoryService.Application.Departments.Commands.SoftDeleteDepartments;
@@ -7,6 +8,7 @@ using DirectoryService.Application.Departments.Queries.GetDepartmentChildren;
 using DirectoryService.Application.Departments.Queries.GetDepartments;
 using DirectoryService.Application.Departments.Queries.GetDepartmentTreeRoots;
 using DirectoryService.Application.Departments.Queries.GetTopFiveDepartmentsWithMostPositions;
+using DirectoryService.Contracts.Departments.ChangeActivity;
 using DirectoryService.Contracts.Departments.CreateDepartments;
 using DirectoryService.Contracts.Departments.GetDepartments.Dtos;
 using DirectoryService.Contracts.Departments.GetDepartments.Requests;
@@ -145,6 +147,18 @@ public class DepartmentsController : ControllerBase
         CancellationToken cancellationToken)
     {
         var command = new RestoreDepartmentCommand(departmentId);
+
+        return await handler.Handle(command, cancellationToken);
+    }
+
+    [HttpPatch("{departmentId:guid}/activity")]
+    public async Task<EndpointResult<Guid>> ChangeActivity(
+        Guid departmentId,
+        [FromServices] ICommandHandler<Guid, ChangeDepartmentActivityCommand> handler,
+        [FromBody] ChangeDepartmentActivityRequest request,
+        CancellationToken cancellationToken)
+    {
+        var command = new ChangeDepartmentActivityCommand(departmentId, request.IsActive);
 
         return await handler.Handle(command, cancellationToken);
     }

--- a/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Commands/ChangeDepartmentActivityTests.cs
+++ b/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Commands/ChangeDepartmentActivityTests.cs
@@ -1,0 +1,166 @@
+﻿using System.Net;
+using System.Net.Http.Json;
+using CSharpFunctionalExtensions;
+using DirectoryService.Application.Departments.Commands.ChangeDepartmentActivity;
+using DirectoryService.Contracts.Departments.ChangeActivity;
+using DirectoryService.Domain.Departments;
+using DirectoryService.IntegrationTests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using SharedService.SharedKernel;
+
+namespace DirectoryService.IntegrationTests.Departments.Commands;
+
+public class ChangeDepartmentActivityTests(DirectoryTestWebFactory factory) : DirectoryBaseTests(factory)
+{
+    private readonly HttpClient _client = factory.CreateClient();
+
+    [Fact]
+    public async Task ChangeActivity_WhenDepartmentIsActive_ShouldDeactivateWithoutArchiving()
+    {
+        var locationId = await CreateLocation();
+        var company = await CreateParentDepartment("company", "company", [locationId]);
+        var command = new ChangeDepartmentActivityCommand(company.Id.Value, false);
+
+        var result = await Execute(command);
+
+        Assert.True(result.IsSuccess);
+
+        await ExecuteInDb(async dbContext =>
+        {
+            var department = await dbContext.Departments.SingleAsync(d => d.Id == company.Id);
+
+            Assert.False(department.IsActive);
+            Assert.Null(department.DeletedAt);
+        });
+    }
+
+    [Fact]
+    public async Task ChangeActivity_WhenDepartmentIsInactive_ShouldActivate()
+    {
+        var locationId = await CreateLocation();
+        var company = await CreateParentDepartment("company", "company", [locationId]);
+
+        await ExecuteInDb(async dbContext =>
+        {
+            var department = await dbContext.Departments.SingleAsync(d => d.Id == company.Id);
+            department.SetActivity(false);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var command = new ChangeDepartmentActivityCommand(company.Id.Value, true);
+
+        var result = await Execute(command);
+
+        Assert.True(result.IsSuccess);
+
+        await ExecuteInDb(async dbContext =>
+        {
+            var department = await dbContext.Departments.SingleAsync(d => d.Id == company.Id);
+
+            Assert.True(department.IsActive);
+            Assert.Null(department.DeletedAt);
+        });
+    }
+
+    [Fact]
+    public async Task ChangeActivity_WhenDepartmentIsArchived_ShouldFailWithoutRestoring()
+    {
+        var locationId = await CreateLocation();
+        var company = await CreateParentDepartment("company", "company", [locationId]);
+        await MarkDepartmentAsDeleted(company.Id);
+
+        var command = new ChangeDepartmentActivityCommand(company.Id.Value, true);
+
+        var result = await Execute(command);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains(result.Error, error => error.Code == "department.activity.archived");
+
+        await ExecuteInDb(async dbContext =>
+        {
+            var department = await dbContext.Departments.SingleAsync(d => d.Id == company.Id);
+
+            Assert.False(department.IsActive);
+            Assert.NotNull(department.DeletedAt);
+        });
+    }
+
+    [Fact]
+    public async Task ChangeActivity_WhenDepartmentHasActiveDescendant_ShouldNotDeactivate()
+    {
+        var locationId = await CreateLocation();
+        var company = await CreateParentDepartment("company", "company", [locationId]);
+        await CreateChildDepartment("development", "development", company, [locationId]);
+
+        var command = new ChangeDepartmentActivityCommand(company.Id.Value, false);
+
+        var result = await Execute(command);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains(result.Error, error => error.Code == "department.activity.active_descendants");
+
+        await ExecuteInDb(async dbContext =>
+        {
+            var department = await dbContext.Departments.SingleAsync(d => d.Id == company.Id);
+            Assert.True(department.IsActive);
+        });
+    }
+
+    [Fact]
+    public async Task ChangeActivity_WhenParentIsInactive_ShouldNotActivateChild()
+    {
+        var locationId = await CreateLocation();
+        var company = await CreateParentDepartment("company", "company", [locationId]);
+        var development = await CreateChildDepartment("development", "development", company, [locationId]);
+
+        await ExecuteInDb(async dbContext =>
+        {
+            var departments = await dbContext.Departments
+                .Where(d => d.Id == company.Id || d.Id == development.Id)
+                .ToListAsync();
+
+            foreach (var department in departments)
+            {
+                department.SetActivity(false);
+            }
+
+            await dbContext.SaveChangesAsync();
+        });
+
+        var command = new ChangeDepartmentActivityCommand(development.Id.Value, true);
+
+        var result = await Execute(command);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains(result.Error, error => error.Code == "department.activity.inactive_parent");
+
+        await ExecuteInDb(async dbContext =>
+        {
+            var department = await dbContext.Departments.SingleAsync(d => d.Id == development.Id);
+            Assert.False(department.IsActive);
+        });
+    }
+
+    [Fact]
+    public async Task ChangeActivityEndpoint_WhenRequestIsValid_ShouldSetRequestedStatus()
+    {
+        var locationId = await CreateLocation();
+        var company = await CreateParentDepartment("company", "company", [locationId]);
+
+        using var response = await _client.PatchAsJsonAsync(
+            $"/api/departments/{company.Id.Value}/activity",
+            new ChangeDepartmentActivityRequest(false));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        await ExecuteInDb(async dbContext =>
+        {
+            var department = await dbContext.Departments.SingleAsync(d => d.Id == company.Id);
+            Assert.False(department.IsActive);
+        });
+    }
+
+    private Task<Result<Guid, Errors>> Execute(ChangeDepartmentActivityCommand command) =>
+        Execute<Result<Guid, Errors>, ChangeDepartmentActivityHandler>(handler =>
+            handler.Handle(command, CancellationToken.None));
+}

--- a/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Commands/ChangeDepartmentActivityTests.cs
+++ b/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Commands/ChangeDepartmentActivityTests.cs
@@ -2,6 +2,7 @@
 using System.Net.Http.Json;
 using CSharpFunctionalExtensions;
 using DirectoryService.Application.Departments.Commands.ChangeDepartmentActivity;
+using DirectoryService.Application.Departments.Commands.SoftDeleteDepartments;
 using DirectoryService.Contracts.Departments.ChangeActivity;
 using DirectoryService.Domain.Departments;
 using DirectoryService.IntegrationTests.Infrastructure;
@@ -107,6 +108,32 @@ public class ChangeDepartmentActivityTests(DirectoryTestWebFactory factory) : Di
     }
 
     [Fact]
+    public async Task ChangeActivity_WhenActiveDescendantIsBehindArchivedDepartment_ShouldDeactivate()
+    {
+        // arrange
+        var locationId = await CreateLocation();
+
+        var company = await CreateParentDepartment("company", "company", [locationId]);
+        var archived = await CreateChildDepartment("archived", "archived", company, [locationId]);
+
+        await CreateChildDepartment("active", "active", archived, [locationId]);
+
+        var archiveResult = await ExecuteSoftDelete(new SoftDeleteDepartmentCommand(archived.Id.Value));
+
+        Assert.True(archiveResult.IsSuccess);
+
+        // act
+        var result = await Execute(new ChangeDepartmentActivityCommand(company.Id.Value, false));
+
+        Assert.True(result.IsSuccess);
+        await ExecuteInDb(async dbContext =>
+        {
+            var department = await dbContext.Departments.SingleAsync(d => d.Id == company.Id);
+            Assert.False(department.IsActive);
+        });
+    }
+
+    [Fact]
     public async Task ChangeActivity_WhenParentIsInactive_ShouldNotActivateChild()
     {
         var locationId = await CreateLocation();
@@ -162,5 +189,9 @@ public class ChangeDepartmentActivityTests(DirectoryTestWebFactory factory) : Di
 
     private Task<Result<Guid, Errors>> Execute(ChangeDepartmentActivityCommand command) =>
         Execute<Result<Guid, Errors>, ChangeDepartmentActivityHandler>(handler =>
+            handler.Handle(command, CancellationToken.None));
+
+    private Task<Result<Guid, Errors>> ExecuteSoftDelete(SoftDeleteDepartmentCommand command) =>
+        Execute<Result<Guid, Errors>, SoftDeleteDepartmentHandler>(handler =>
             handler.Handle(command, CancellationToken.None));
 }

--- a/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Commands/CreateDepartmentTests.cs
+++ b/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Commands/CreateDepartmentTests.cs
@@ -18,11 +18,10 @@ public class CreateDepartmentTests : DirectoryBaseTests
     public async Task CreateDepartmentWithoutLocationShouldFailed()
     {
         // arrange
-        var cancellationToken = CancellationToken.None;
+        var command = CreateCommand("подразделение", "company", null, []);
 
         // act
-        var result = await Execute(
-            new CreateDepartmentCommand(new CreateDepartmentRequest("подразделение", "company", null, [])));
+        var result = await Execute(command);
 
         // assert
         Assert.NotEmpty(result.Error);
@@ -39,10 +38,10 @@ public class CreateDepartmentTests : DirectoryBaseTests
 
         await CreateParentDepartment("подразделение", "company", [locationId]);
 
+        var command = CreateCommand("подразделение", "company", null, [locationId.Value]);
+
         // act
-        var result = await Execute(
-            new CreateDepartmentCommand(
-                new CreateDepartmentRequest("подразделение", "company", null, [locationId.Value])));
+        var result = await Execute(command);
 
         // assert
         Assert.NotEmpty(result.Error);
@@ -55,16 +54,30 @@ public class CreateDepartmentTests : DirectoryBaseTests
         // arrange
         var locationId = await CreateLocation("локация");
 
-        var cancellationToken = CancellationToken.None;
+        var command = CreateCommand(string.Empty, "company", null, [locationId.Value]);
 
         // act
-        var result = await Execute(
-            new CreateDepartmentCommand(
-                new CreateDepartmentRequest(string.Empty, "company", null, [locationId.Value])));
+        var result = await Execute(command);
 
         // assert
         Assert.NotEmpty(result.Error);
         Assert.True(result.IsFailure);
+    }
+
+    [Fact]
+    public async Task CreateDepartment_WhenIdentifierUsesArchivedPathPrefix_ShouldFail()
+    {
+        // arrange
+        var locationId = await CreateLocation("локация");
+
+        var command = CreateCommand("подразделение", "delete-company", null, [locationId.Value]);
+
+        // act
+        var result = await Execute(command);
+
+        // assert
+        Assert.True(result.IsFailure);
+        Assert.Contains(result.Error, error => error.InvalidField == "department.identifier");
     }
 
     [Fact]
@@ -77,10 +90,10 @@ public class CreateDepartmentTests : DirectoryBaseTests
 
         var parent = await CreateParentDepartment("подразделение", "company", [locationId]);
 
+        var command = CreateCommand("подразделение 1", "sales", parent.Id.Value, [locationId.Value]);
+
         // act
-        var result = await Execute(
-            new CreateDepartmentCommand(
-                new CreateDepartmentRequest("подразделение 1", "sales", parent.Id.Value, [locationId.Value])));
+        var result = await Execute(command);
 
         // assert
         await ExecuteInDb(async dbContext =>
@@ -104,10 +117,10 @@ public class CreateDepartmentTests : DirectoryBaseTests
 
         var cancellationToken = CancellationToken.None;
 
+        var command = CreateCommand("подразделение", "company", null, [locationId.Value]);
+
         // act
-        var result = await Execute(
-            new CreateDepartmentCommand(
-                new CreateDepartmentRequest("подразделение", "company", null, [locationId.Value])));
+        var result = await Execute(command);
 
         // assert
         await ExecuteInDb(async dbContext =>
@@ -122,6 +135,10 @@ public class CreateDepartmentTests : DirectoryBaseTests
         Assert.True(result.IsSuccess);
         Assert.NotEqual(Guid.Empty, result.Value);
     }
+
+    private static CreateDepartmentCommand CreateCommand(
+        string name, string identifier, Guid? parentId, Guid[] locationIds) =>
+        new(new CreateDepartmentRequest(name, identifier, parentId, locationIds));
 
     private Task<Result<Guid, Errors>> Execute(CreateDepartmentCommand command)
         => Execute<Result<Guid, Errors>, CreateDepartmentHandler>(handler => handler.Handle(

--- a/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Commands/RestoreDepartmentTests.cs
+++ b/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Commands/RestoreDepartmentTests.cs
@@ -498,6 +498,35 @@ public class RestoreDepartmentTests(DirectoryTestWebFactory factory) : Directory
     }
 
     [Fact]
+    public async Task RestoreDepartment_WhenDepartmentIsInactiveButNotArchived_ShouldFail()
+    {
+        // arrange
+        var locationId = await CreateLocation();
+        var department = await CreateParentDepartment("company", "company", [locationId]);
+
+        await ExecuteInDb(async dbContext =>
+        {
+            var storedDepartment = await dbContext.Departments.SingleAsync(d => d.Id == department.Id);
+            storedDepartment.SetActivity(false);
+            await dbContext.SaveChangesAsync();
+        });
+
+        // act
+        var result = await Execute(new RestoreDepartmentCommand(department.Id.Value));
+
+        // assert
+        Assert.True(result.IsFailure);
+        Assert.Contains(result.Error, error => error.Code == "department.restore.not_archived");
+
+        await ExecuteInDb(async dbContext =>
+        {
+            var storedDepartment = await dbContext.Departments.SingleAsync(d => d.Id == department.Id);
+            Assert.False(storedDepartment.IsActive);
+            Assert.Null(storedDepartment.DeletedAt);
+        });
+    }
+
+    [Fact]
     public async Task RestoreDepartment_WhenParentIsActive_ShouldSucceed()
     {
         // arrange

--- a/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Commands/SoftDeleteDepartmentTests.cs
+++ b/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Commands/SoftDeleteDepartmentTests.cs
@@ -286,6 +286,33 @@ public class SoftDeleteDepartmentTests(DirectoryTestWebFactory factory) : Direct
         });
     }
 
+    [Fact]
+    public async Task SoftDeleteDepartment_WhenDepartmentIsInactive_ShouldArchiveIt()
+    {
+        // arrange
+        var locationId = await CreateLocation();
+        var company = await CreateParentDepartment("company", "company", [locationId]);
+
+        await ExecuteInDb(async dbContext =>
+        {
+            var department = await dbContext.Departments.SingleAsync(d => d.Id == company.Id);
+            department.SetActivity(false);
+            await dbContext.SaveChangesAsync();
+        });
+
+        // act
+        var result = await Execute(new SoftDeleteDepartmentCommand(company.Id.Value));
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        await ExecuteInDb(async dbContext =>
+        {
+            var department = await dbContext.Departments.SingleAsync(d => d.Id == company.Id);
+            Assert.False(department.IsActive);
+            Assert.NotNull(department.DeletedAt);
+        });
+    }
+
     private Task<Result<Guid, Errors>> Execute(SoftDeleteDepartmentCommand command) =>
         Execute<Result<Guid, Errors>, SoftDeleteDepartmentHandler>(handler => handler.Handle(command));
 }

--- a/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Queries/GetDepartmentChildrenTests.cs
+++ b/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Queries/GetDepartmentChildrenTests.cs
@@ -2,7 +2,9 @@
 using DirectoryService.Application.Departments.Queries.GetDepartmentChildren;
 using DirectoryService.Contracts.Departments.GetDepartments.Dtos;
 using DirectoryService.Contracts.Departments.GetDepartments.Requests;
+using DirectoryService.Domain.Departments;
 using DirectoryService.IntegrationTests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
 using SharedService.SharedKernel;
 using SharedService.SharedKernel.Response;
 
@@ -293,6 +295,59 @@ public class GetDepartmentChildrenTests(DirectoryTestWebFactory factory) : Direc
     }
 
     [Fact]
+    public async Task GetDepartmentChildren_WhenOnlyActiveIsFalse_ShouldReturnActiveAndInactiveChildren()
+    {
+        var locationId = await CreateLocation();
+        var company = await CreateParentDepartment("company", "company", [locationId]);
+        var active = await CreateChildDepartment("active", "active", company, [locationId]);
+        var inactive = await CreateChildDepartment("inactive", "inactive", company, [locationId]);
+        await SetDepartmentActivity(inactive.Id, false);
+
+        var result = await Execute(CreateQuery(company.Id.Value, onlyActive: false));
+
+        Assert.True(result.IsSuccess);
+        Assert.Contains(result.Value.Items, department => department.Id == active.Id.Value);
+        Assert.Contains(result.Value.Items, department => department.Id == inactive.Id.Value);
+    }
+
+    [Fact]
+    public async Task GetDepartmentChildren_WhenOnlyActiveIsTrue_ShouldReturnOnlyActiveChildren()
+    {
+        var locationId = await CreateLocation();
+        var company = await CreateParentDepartment("company", "company", [locationId]);
+        var active = await CreateChildDepartment("active", "active", company, [locationId]);
+        var inactive = await CreateChildDepartment("inactive", "inactive", company, [locationId]);
+        await SetDepartmentActivity(inactive.Id, false);
+
+        var result = await Execute(CreateQuery(company.Id.Value, onlyActive: true));
+
+        Assert.True(result.IsSuccess);
+        var child = Assert.Single(result.Value.Items);
+        Assert.Equal(active.Id.Value, child.Id);
+    }
+
+    [Fact]
+    public async Task GetDepartmentChildren_WhenOnlyActiveAndDescendantIsInactive_ShouldSetHasChildrenToFalse()
+    {
+        // arrange
+        var locationId = await CreateLocation();
+
+        var company = await CreateParentDepartment("company", "company", [locationId]);
+        var backend = await CreateChildDepartment("backend", "backend", company, [locationId]);
+        var inactive = await CreateChildDepartment("inactive", "inactive", backend, [locationId]);
+
+        await SetDepartmentActivity(inactive.Id, false);
+
+        // act
+        var result = await Execute(CreateQuery(company.Id.Value, onlyActive: true));
+
+        // assert
+        Assert.True(result.IsSuccess);
+        var child = Assert.Single(result.Value.Items);
+        Assert.False(child.HasChildren);
+    }
+
+    [Fact]
     public async Task GetDepartmentChildren_WhenChildHasActiveDescendant_ShouldSetHasChildrenToTrue()
     {
         // arrange
@@ -360,10 +415,19 @@ public class GetDepartmentChildrenTests(DirectoryTestWebFactory factory) : Direc
     private static GetDepartmentChildrenQuery CreateQuery(
         Guid parentId,
         int page = 1,
-        int pageSize = 20) =>
+        int pageSize = 20,
+        bool onlyActive = false) =>
         new(
             parentId,
-            new GetDepartmentChildrenRequest { Page = page, PageSize = pageSize });
+            new GetDepartmentChildrenRequest(onlyActive) { Page = page, PageSize = pageSize });
+
+    private Task SetDepartmentActivity(DepartmentId departmentId, bool isActive) =>
+        ExecuteInDb(async dbContext =>
+        {
+            var department = await dbContext.Departments.SingleAsync(d => d.Id == departmentId);
+            department.SetActivity(isActive);
+            await dbContext.SaveChangesAsync();
+        });
 
     private Task<Result<PaginationEnvelope<GetDepartmentChildrenDto>, Errors>> Execute(GetDepartmentChildrenQuery query)
         => Execute<Result<PaginationEnvelope<GetDepartmentChildrenDto>, Errors>,

--- a/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Queries/GetDepartmentTreeRootsTests.cs
+++ b/backend/DirectoryService/tests/DirectoryService.IntegrationTests/Departments/Queries/GetDepartmentTreeRootsTests.cs
@@ -2,7 +2,9 @@
 using DirectoryService.Application.Departments.Queries.GetDepartmentTreeRoots;
 using DirectoryService.Contracts.Departments.GetDepartments.Dtos;
 using DirectoryService.Contracts.Departments.GetDepartments.Requests;
+using DirectoryService.Domain.Departments;
 using DirectoryService.IntegrationTests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
 using SharedService.SharedKernel;
 using SharedService.SharedKernel.Response;
 
@@ -139,6 +141,70 @@ public class GetDepartmentTreeRootsTests(DirectoryTestWebFactory factory) : Dire
     }
 
     [Fact]
+    public async Task GetDepartmentTreeRoots_WhenOnlyActiveIsFalse_ShouldReturnActiveAndInactiveRoots()
+    {
+        // arrange
+        var locationId = await CreateLocation();
+
+        var active = await CreateParentDepartment("active", "active", [locationId]);
+        var inactive = await CreateParentDepartment("inactive", "inactive", [locationId]);
+
+        await SetDepartmentActivity(inactive.Id, false);
+        await ClearDepartmentCache();
+
+        // act
+        var result = await Execute(CreateQuery(onlyActive: false));
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Contains(result.Value.Items, department => department.Id == active.Id.Value);
+        Assert.Contains(result.Value.Items, department => department.Id == inactive.Id.Value);
+    }
+
+    [Fact]
+    public async Task GetDepartmentTreeRoots_WhenOnlyActiveIsTrue_ShouldReturnOnlyActiveRoots()
+    {
+        // arrange
+        var locationId = await CreateLocation();
+
+        var active = await CreateParentDepartment("active", "active", [locationId]);
+        var inactive = await CreateParentDepartment("inactive", "inactive", [locationId]);
+
+        await SetDepartmentActivity(inactive.Id, false);
+        await ClearDepartmentCache();
+
+        // act
+        var result = await Execute(CreateQuery(onlyActive: true));
+
+        // assert
+        Assert.True(result.IsSuccess);
+        var root = Assert.Single(result.Value.Items);
+        Assert.Equal(active.Id.Value, root.Id);
+    }
+
+    [Fact]
+    public async Task GetDepartmentTreeRoots_WhenOnlyActiveAndChildrenAreInactive_ShouldHideChildren()
+    {
+        // arrange
+        var locationId = await CreateLocation();
+
+        var company = await CreateParentDepartment("company", "company", [locationId]);
+        var inactive = await CreateChildDepartment("inactive", "inactive", company, [locationId]);
+
+        await SetDepartmentActivity(inactive.Id, false);
+        await ClearDepartmentCache();
+
+        // act
+        var result = await Execute(CreateQuery(onlyActive: true));
+
+        // arrange
+        Assert.True(result.IsSuccess);
+        var root = Assert.Single(result.Value.Items);
+        Assert.False(root.HasChildren);
+        Assert.Empty(root.Children);
+    }
+
+    [Fact]
     public async Task GetDepartmentTreeRoots_WhenPrefetchIsSpecified_ShouldReturnLimitedDirectChildren()
     {
         // arrange
@@ -166,8 +232,16 @@ public class GetDepartmentTreeRootsTests(DirectoryTestWebFactory factory) : Dire
         Assert.Equal(prefetch, root.Children.Count);
     }
 
-    private static GetDepartmentTreeRootsQuery CreateQuery(int prefetch = 3) =>
-        new(new GetDepartmentTreeRootsRequest(prefetch));
+    private static GetDepartmentTreeRootsQuery CreateQuery(int prefetch = 3, bool onlyActive = false) =>
+        new(new GetDepartmentTreeRootsRequest(prefetch, onlyActive));
+
+    private Task SetDepartmentActivity(DepartmentId departmentId, bool isActive) =>
+        ExecuteInDb(async dbContext =>
+        {
+            var department = await dbContext.Departments.SingleAsync(d => d.Id == departmentId);
+            department.SetActivity(isActive);
+            await dbContext.SaveChangesAsync();
+        });
 
     private Task<Result<PaginationEnvelope<GetDepartmentTreeRootsDto>, Errors>> Execute(
         GetDepartmentTreeRootsQuery query)

--- a/frontend/src/entities/departments/api/api.ts
+++ b/frontend/src/entities/departments/api/api.ts
@@ -1,9 +1,9 @@
-import { apiClient } from "@/shared/api/axios-instance";
 import {
+	apiClient,
 	Envelope,
 	envelopeInfinityQueryOptions,
 	PaginationEnvelope,
-} from "@/shared/api/envelops";
+} from "@/shared/api";
 import { infiniteQueryOptions } from "@tanstack/react-query";
 import {
 	DepartmentId,
@@ -11,6 +11,7 @@ import {
 	DepartmentTreeDto,
 } from "../model/types";
 import {
+	type ChangeDepartmentActivityRequest,
 	GetDepartmentChildrenRequest,
 	GetDepartmentsInfinityRequest,
 	GetDepartmentsRequest,
@@ -110,6 +111,18 @@ export const departmentsApi = {
 		const response = await apiClient.put<Envelope<DepartmentId>>(
 			`${DEPARTMENTS_ENDPOINT}/${request.departmentId}/parent`,
 			{ parentId: request.parentId },
+		);
+
+		return response.data;
+	},
+
+	changeDepartmentActivity: async ({
+		departmentId,
+		isActive,
+	}: ChangeDepartmentActivityRequest) => {
+		const response = await apiClient.patch<Envelope<DepartmentId>>(
+			`${DEPARTMENTS_ENDPOINT}/${departmentId}/activity`,
+			{ isActive },
 		);
 
 		return response.data;

--- a/frontend/src/entities/departments/api/department-activity-cache.ts
+++ b/frontend/src/entities/departments/api/department-activity-cache.ts
@@ -1,0 +1,113 @@
+import type { Envelope, PaginationEnvelope } from "@/shared/api";
+import type {
+	InfiniteData,
+	QueryClient,
+	QueryKey,
+} from "@tanstack/react-query";
+import { departmentsApi } from "./api";
+import type { ChangeDepartmentActivityRequest } from "./types";
+import type { DepartmentId } from "../model/types";
+
+type DepartmentCacheItem = {
+	id: DepartmentId;
+	isActive: boolean;
+};
+
+type DepartmentQueryData = InfiniteData<
+	Envelope<PaginationEnvelope<DepartmentCacheItem>>
+>;
+
+export type DepartmentQueriesSnapshot = [
+	QueryKey,
+	DepartmentQueryData | undefined,
+][];
+
+export function optimisticallyUpdateDepartmentActivity(
+	queryClient: QueryClient,
+	request: ChangeDepartmentActivityRequest,
+): DepartmentQueriesSnapshot {
+	const snapshots = queryClient.getQueriesData<DepartmentQueryData>({
+		queryKey: [departmentsApi.baseKey],
+	});
+
+	for (const [queryKey, data] of snapshots) {
+		queryClient.setQueryData(
+			queryKey,
+			updateDepartmentQueryData(data, queryKey, request),
+		);
+	}
+
+	return snapshots;
+}
+
+export function restoreDepartmentQueries(
+	queryClient: QueryClient,
+	snapshots: DepartmentQueriesSnapshot,
+) {
+	for (const [queryKey, data] of snapshots) {
+		queryClient.setQueryData(queryKey, data);
+	}
+}
+
+function updateDepartmentQueryData(
+	data: DepartmentQueryData | undefined,
+	queryKey: QueryKey,
+	request: ChangeDepartmentActivityRequest,
+): DepartmentQueryData | undefined {
+	if (!data) return data;
+
+	const containsDepartment = data.pages.some((page) =>
+		page.result?.items.some(
+			(department) => department.id === request.departmentId,
+		),
+	);
+	if (!containsDepartment) return data;
+
+	const removeFromQuery = doesActivityFilterExclude(queryKey, request.isActive);
+
+	return {
+		...data,
+		pages: data.pages.map((page) => {
+			if (!page.result) return page;
+
+			const items = removeFromQuery
+				? page.result.items.filter(
+						(department) => department.id !== request.departmentId,
+					)
+				: page.result.items.map((department) =>
+						department.id === request.departmentId
+							? { ...department, isActive: request.isActive }
+							: department,
+					);
+
+			return {
+				...page,
+				result: {
+					...page.result,
+					items,
+					totalCount: removeFromQuery
+						? Math.max(0, page.result.totalCount - 1)
+						: page.result.totalCount,
+				},
+			};
+		}),
+	};
+}
+
+function doesActivityFilterExclude(
+	queryKey: QueryKey,
+	isActive: boolean,
+): boolean {
+	const request = queryKey[2];
+	if (!request || typeof request !== "object") return false;
+
+	if ("onlyActive" in request && request.onlyActive === true) {
+		return !isActive;
+	}
+
+	return (
+		"isActive" in request &&
+		typeof request.isActive === "boolean" &&
+		request.isActive !== isActive
+	);
+}

--- a/frontend/src/entities/departments/api/types.ts
+++ b/frontend/src/entities/departments/api/types.ts
@@ -1,11 +1,11 @@
-import { InfinityScrollRequest } from "@/shared/api/infinity-scroll-request";
-import { PaginationRequest } from "@/shared/api/pagination-request";
-import { SortDirectionFilter } from "@/shared/model/filter-types";
+import type { InfinityScrollRequest, PaginationRequest } from "@/shared/api";
+import type { SortDirectionFilter } from "@/shared/model";
 
 export interface GetDepartmentsRequest extends PaginationRequest {
 	locationIds?: string[];
 	search?: string;
 	isActive?: boolean;
+	isArchived?: boolean;
 	isParent?: boolean;
 	parentId?: string;
 	sortBy?: string;
@@ -16,6 +16,7 @@ export interface GetDepartmentsInfinityRequest extends InfinityScrollRequest {
 	locationIds?: string[];
 	search?: string;
 	isActive?: boolean;
+	isArchived?: boolean;
 	isParent?: boolean;
 	parentId?: string;
 	sortBy?: string;
@@ -24,10 +25,17 @@ export interface GetDepartmentsInfinityRequest extends InfinityScrollRequest {
 
 export interface GetDepartmentTreeRootsRequest extends PaginationRequest {
 	prefetch?: number;
+	onlyActive?: boolean;
 }
 
 export interface GetDepartmentChildrenRequest extends PaginationRequest {
 	parentId: string;
+	onlyActive?: boolean;
+}
+
+export interface ChangeDepartmentActivityRequest {
+	departmentId: string;
+	isActive: boolean;
 }
 
 export interface MoveDepartmentRequest {

--- a/frontend/src/entities/departments/index.ts
+++ b/frontend/src/entities/departments/index.ts
@@ -1,6 +1,11 @@
 export { departmentsApi } from "./api/api";
+export {
+	optimisticallyUpdateDepartmentActivity,
+	restoreDepartmentQueries,
+} from "./api/department-activity-cache";
 
 export type {
+	ChangeDepartmentActivityRequest,
 	GetDepartmentChildrenRequest,
 	GetDepartmentsInfinityRequest,
 	GetDepartmentsRequest,

--- a/frontend/src/entities/departments/model/department-list-store.ts
+++ b/frontend/src/entities/departments/model/department-list-store.ts
@@ -1,6 +1,6 @@
 import type { DepartmentParentFilter, DepartmentSortByFilter } from "./types";
-import { PAGE_SIZE } from "@/shared/api/pagination-request";
-import { ActiveFilter, SortDirectionFilter } from "@/shared/model/filter-types";
+import { PAGE_SIZE } from "@/shared/api";
+import type { ActiveFilter, SortDirectionFilter } from "@/shared/model";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 

--- a/frontend/src/entities/departments/model/use-infinite-departments-list.ts
+++ b/frontend/src/entities/departments/model/use-infinite-departments-list.ts
@@ -1,7 +1,7 @@
 import { departmentsApi } from "../api/api";
 import type { GetDepartmentsInfinityRequest } from "../api/types";
-import { EnvelopeError } from "@/shared/api/errors";
-import { useCursorRef } from "@/shared/hooks/use-cursor-ref";
+import { EnvelopeError } from "@/shared/api";
+import { useCursorRef } from "@/shared/hooks";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useDebounce } from "use-debounce";
 import {

--- a/frontend/src/features/department-tree/model/department-tree-store.ts
+++ b/frontend/src/features/department-tree/model/department-tree-store.ts
@@ -7,6 +7,7 @@ export type DepartmentTreeId = string;
 type DepartmentTreeState = {
 	selectedId: DepartmentId | null;
 	expandedIds: DepartmentId[];
+	onlyActive: boolean;
 };
 
 type DepartmentTreeStates = Record<
@@ -17,6 +18,7 @@ type DepartmentTreeStates = Record<
 const initialState: DepartmentTreeState = {
 	selectedId: null,
 	expandedIds: [],
+	onlyActive: false,
 };
 
 const DEFAULT_STATE_ID = "__default__";
@@ -29,7 +31,7 @@ const resolveStateId = (stateId?: DepartmentTreeId) =>
 const getDepartmentTreeState = (
 	states: DepartmentTreeStates,
 	stateId?: DepartmentTreeId,
-) => states[resolveStateId(stateId)] ?? initialState;
+) => ({ ...initialState, ...states[resolveStateId(stateId)] });
 
 const useDepartmentTreeStore = create<DepartmentTreeStates>()(
 	persist(() => ({ ...initialStates }), {
@@ -100,6 +102,22 @@ export const collapseAllDepartments = (stateId?: DepartmentTreeId) =>
 		[resolveStateId(stateId)]: {
 			...getDepartmentTreeState(states, stateId),
 			expandedIds: [],
+		},
+	}));
+
+export const useDepartmentTreeOnlyActive = (stateId?: DepartmentTreeId) =>
+	useDepartmentTreeStore(
+		(state) => getDepartmentTreeState(state, stateId).onlyActive,
+	);
+
+export const setDepartmentTreeOnlyActive = (
+	onlyActive: boolean,
+	stateId?: DepartmentTreeId,
+) =>
+	useDepartmentTreeStore.setState((states) => ({
+		[resolveStateId(stateId)]: {
+			...getDepartmentTreeState(states, stateId),
+			onlyActive,
 		},
 	}));
 

--- a/frontend/src/features/department-tree/model/use-department-tree-node.ts
+++ b/frontend/src/features/department-tree/model/use-department-tree-node.ts
@@ -34,6 +34,7 @@ export function useDepartmentTreeNode({ department, stateId }: Props) {
 	} = useInfiniteDepartmentChildren({
 		request: { parentId: department.id },
 		enabled: isExpanded && hasChildren,
+		stateId,
 	});
 
 	const handleToggle = () => {

--- a/frontend/src/features/department-tree/model/use-department-tree-roots.ts
+++ b/frontend/src/features/department-tree/model/use-department-tree-roots.ts
@@ -2,14 +2,21 @@ import {
 	departmentsApi,
 	type GetDepartmentTreeRootsRequest,
 } from "@/entities/departments";
-import { useCursorRef } from "@/shared/hooks/use-cursor-ref";
+import { useCursorRef } from "@/shared/hooks";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import {
+	useDepartmentTreeOnlyActive,
+	type DepartmentTreeId,
+} from "./department-tree-store";
 
 type Props = {
 	request?: GetDepartmentTreeRootsRequest;
+	stateId?: DepartmentTreeId;
 };
 
-export function useDepartmentTreeRoots({ request }: Props) {
+export function useDepartmentTreeRoots({ request, stateId }: Props) {
+	const onlyActive = useDepartmentTreeOnlyActive(stateId);
+
 	const {
 		data,
 		isPending,
@@ -23,6 +30,7 @@ export function useDepartmentTreeRoots({ request }: Props) {
 	} = useInfiniteQuery({
 		...departmentsApi.getDepartmentTreeRootsInfinityQueryOptions({
 			...request,
+			onlyActive,
 		}),
 	});
 

--- a/frontend/src/features/department-tree/model/use-infinite-department-children.ts
+++ b/frontend/src/features/department-tree/model/use-infinite-department-children.ts
@@ -2,15 +2,26 @@ import {
 	departmentsApi,
 	type GetDepartmentChildrenRequest,
 } from "@/entities/departments";
-import { EnvelopeError } from "@/shared/api/errors";
+import { EnvelopeError } from "@/shared/api";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import {
+	type DepartmentTreeId,
+	useDepartmentTreeOnlyActive,
+} from "./department-tree-store";
 
 type Props = {
 	request: GetDepartmentChildrenRequest;
 	enabled: boolean;
+	stateId?: DepartmentTreeId;
 };
 
-export function useInfiniteDepartmentChildren({ request, enabled }: Props) {
+export function useInfiniteDepartmentChildren({
+	request,
+	enabled,
+	stateId,
+}: Props) {
+	const onlyActive = useDepartmentTreeOnlyActive(stateId);
+
 	const {
 		data,
 		isLoading,
@@ -22,7 +33,10 @@ export function useInfiniteDepartmentChildren({ request, enabled }: Props) {
 		fetchNextPage,
 		refetch,
 	} = useInfiniteQuery({
-		...departmentsApi.getDepartmentChildrenInfinityOptions({ ...request }),
+		...departmentsApi.getDepartmentChildrenInfinityOptions({
+			...request,
+			onlyActive,
+		}),
 		enabled: enabled,
 	});
 

--- a/frontend/src/features/department-tree/ui/department-tree-roots-list.tsx
+++ b/frontend/src/features/department-tree/ui/department-tree-roots-list.tsx
@@ -10,10 +10,13 @@ import type { ReactNode } from "react";
 import {
 	collapseAllDepartments,
 	DepartmentTreeId,
+	setDepartmentTreeOnlyActive,
 	useDepartmentTreeExpandedIds,
+	useDepartmentTreeOnlyActive,
 } from "../model/department-tree-store";
 import { useDepartmentTreeRoots } from "../model/use-department-tree-roots";
 import { DepartmentTreeNode } from "./department-tree-node";
+import { Checkbox } from "@/shared/components/ui/checkbox";
 
 type Props = {
 	stateId?: DepartmentTreeId;
@@ -31,11 +34,17 @@ export function DepartmentTreeRootsList({ stateId, renderActions }: Props) {
 		isFetchNextPageError,
 		fetchNextPage,
 		refetch,
-	} = useDepartmentTreeRoots({});
+	} = useDepartmentTreeRoots({ stateId });
 
 	const expandedIds = useDepartmentTreeExpandedIds(stateId);
+	const onlyActive = useDepartmentTreeOnlyActive(stateId);
 
 	const hasExpandedBranches = expandedIds.length > 0;
+
+	const handleActiveChange = (checked: boolean | "indeterminate") => {
+		setDepartmentTreeOnlyActive(checked === true, stateId);
+		collapseAllDepartments(stateId);
+	};
 	return (
 		<section className="bg-background flex h-full min-h-0 w-full flex-col rounded-xl border">
 			<div className="flex items-center justify-between border-b px-4 py-3">
@@ -45,6 +54,11 @@ export function DepartmentTreeRootsList({ stateId, renderActions }: Props) {
 						Выберите отдел из дерева
 					</p>
 				</div>
+
+				<label className="flex items-center gap-2 text-sm">
+					<Checkbox checked={onlyActive} onCheckedChange={handleActiveChange} />
+					Только активные
+				</label>
 
 				<div>
 					<Button

--- a/frontend/src/features/toggle-department-activity/index.ts
+++ b/frontend/src/features/toggle-department-activity/index.ts
@@ -1,0 +1,1 @@
+export { ToggleDepartmentActivity } from "./ui/toggle-department-activity";

--- a/frontend/src/features/toggle-department-activity/model/use-toggle-department-activity.test.tsx
+++ b/frontend/src/features/toggle-department-activity/model/use-toggle-department-activity.test.tsx
@@ -1,0 +1,233 @@
+import type { DepartmentShortDto } from "@/entities/departments";
+import {
+	EnvelopeError,
+	type Envelope,
+	type PaginationEnvelope,
+} from "@/shared/api";
+import {
+	QueryClient,
+	QueryClientProvider,
+	type InfiniteData,
+} from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useToggleDepartmentActivity } from "./use-toggle-department-activity";
+
+const mocks = vi.hoisted(() => ({
+	changeDepartmentActivity: vi.fn(),
+	error: vi.fn(),
+	success: vi.fn(),
+}));
+
+vi.mock("@/entities/departments", async (importOriginal) => {
+	const original =
+		await importOriginal<typeof import("@/entities/departments")>();
+
+	return {
+		...original,
+		departmentsApi: {
+			baseKey: "departments",
+			changeDepartmentActivity: mocks.changeDepartmentActivity,
+		},
+	};
+});
+
+vi.mock("sonner", () => ({
+	toast: {
+		error: mocks.error,
+		success: mocks.success,
+	},
+}));
+
+type DepartmentData = InfiniteData<
+	Envelope<PaginationEnvelope<DepartmentShortDto>>
+>;
+
+const department: DepartmentShortDto = {
+	id: "department-id",
+	name: "Разработка",
+	identifier: "development",
+	path: "development",
+	isActive: true,
+	createdAt: "2026-08-24T00:00:00Z",
+	updatedAt: "2026-08-24T00:00:00Z",
+	deletedAt: null,
+};
+
+function createData(): DepartmentData {
+	return {
+		pages: [
+			{
+				result: {
+					items: [department],
+					totalCount: 1,
+					page: 1,
+					pageSize: 20,
+					totalPages: 1,
+				},
+				errorsList: [],
+				isError: false,
+				timeGenerated: "2026-08-24T00:00:00Z",
+			},
+		],
+		pageParams: [1],
+	};
+}
+
+function createWrapper(client: QueryClient) {
+	return function Wrapper({ children }: PropsWithChildren) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+describe("useToggleDepartmentActivity", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("optimistically updates the activity state before the request completes", async () => {
+		const client = new QueryClient({
+			defaultOptions: { mutations: { retry: false } },
+		});
+		const queryKey = ["departments", "list", { isActive: undefined }] as const;
+		client.setQueryData(queryKey, createData());
+		let resolveMutation!: (value: { result: string }) => void;
+		mocks.changeDepartmentActivity.mockReturnValue(
+			new Promise((resolve) => {
+				resolveMutation = resolve;
+			}),
+		);
+
+		const { result } = renderHook(() => useToggleDepartmentActivity(), {
+			wrapper: createWrapper(client),
+		});
+
+		act(() => {
+			result.current.toggleDepartmentActivity({
+				departmentId: department.id,
+				isActive: false,
+			});
+		});
+
+		await waitFor(() => {
+			const data = client.getQueryData<DepartmentData>(queryKey);
+			expect(data?.pages[0].result?.items[0].isActive).toBe(false);
+		});
+		expect(result.current.isPending).toBe(true);
+
+		act(() => resolveMutation({ result: department.id }));
+		await waitFor(() => expect(result.current.isPending).toBe(false));
+		expect(mocks.success).not.toHaveBeenCalled();
+	});
+
+	it("removes a deactivated department from only-active queries", async () => {
+		const client = new QueryClient({
+			defaultOptions: { mutations: { retry: false } },
+		});
+		const queryKey = [
+			"departments",
+			"tree-roots",
+			{ onlyActive: true },
+		] as const;
+		client.setQueryData(queryKey, createData());
+		mocks.changeDepartmentActivity.mockResolvedValue({ result: department.id });
+
+		const { result } = renderHook(() => useToggleDepartmentActivity(), {
+			wrapper: createWrapper(client),
+		});
+
+		act(() => {
+			result.current.toggleDepartmentActivity({
+				departmentId: department.id,
+				isActive: false,
+			});
+		});
+
+		await waitFor(() => {
+			const data = client.getQueryData<DepartmentData>(queryKey);
+			expect(data?.pages[0].result?.items).toEqual([]);
+			expect(data?.pages[0].result?.totalCount).toBe(0);
+		});
+	});
+
+	it("removes an activated department from inactive-only queries", async () => {
+		const client = new QueryClient({
+			defaultOptions: { mutations: { retry: false } },
+		});
+		const queryKey = ["departments", "list", { isActive: false }] as const;
+		const data = createData();
+		data.pages[0].result!.items[0] = { ...department, isActive: false };
+		client.setQueryData(queryKey, data);
+		mocks.changeDepartmentActivity.mockResolvedValue({ result: department.id });
+
+		const { result } = renderHook(() => useToggleDepartmentActivity(), {
+			wrapper: createWrapper(client),
+		});
+
+		act(() => {
+			result.current.toggleDepartmentActivity({
+				departmentId: department.id,
+				isActive: true,
+			});
+		});
+
+		await waitFor(() => {
+			const updatedData = client.getQueryData<DepartmentData>(queryKey);
+			expect(updatedData?.pages[0].result?.items).toEqual([]);
+			expect(updatedData?.pages[0].result?.totalCount).toBe(0);
+		});
+	});
+
+	it("rolls cache back and shows a backend business error", async () => {
+		const client = new QueryClient({
+			defaultOptions: { mutations: { retry: false } },
+		});
+		const queryKey = ["departments", "list", { isActive: undefined }] as const;
+		client.setQueryData(queryKey, createData());
+		let rejectMutation!: (reason: EnvelopeError) => void;
+		mocks.changeDepartmentActivity.mockReturnValue(
+			new Promise((_resolve, reject) => {
+				rejectMutation = reject;
+			}),
+		);
+
+		const { result } = renderHook(() => useToggleDepartmentActivity(), {
+			wrapper: createWrapper(client),
+		});
+
+		act(() => {
+			result.current.toggleDepartmentActivity({
+				departmentId: department.id,
+				isActive: false,
+			});
+		});
+
+		await waitFor(() => {
+			const data = client.getQueryData<DepartmentData>(queryKey);
+			expect(data?.pages[0].result?.items[0].isActive).toBe(false);
+		});
+
+		act(() =>
+			rejectMutation(
+				new EnvelopeError([
+					{
+						code: "department.activity.active_descendants",
+						message: "Сначала деактивируйте дочерние подразделения.",
+						type: "conflict",
+					},
+				]),
+			),
+		);
+
+		await waitFor(() => {
+			const data = client.getQueryData<DepartmentData>(queryKey);
+			expect(data?.pages[0].result?.items[0].isActive).toBe(true);
+		});
+		expect(mocks.error).toHaveBeenCalledWith(
+			"Сначала деактивируйте дочерние подразделения.",
+		);
+	});
+});

--- a/frontend/src/features/toggle-department-activity/model/use-toggle-department-activity.ts
+++ b/frontend/src/features/toggle-department-activity/model/use-toggle-department-activity.ts
@@ -1,0 +1,49 @@
+import {
+	departmentsApi,
+	optimisticallyUpdateDepartmentActivity,
+	restoreDepartmentQueries,
+	type ChangeDepartmentActivityRequest,
+} from "@/entities/departments";
+import { EnvelopeError } from "@/shared/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+export function useToggleDepartmentActivity() {
+	const queryClient = useQueryClient();
+
+	const mutation = useMutation({
+		mutationFn: departmentsApi.changeDepartmentActivity,
+		onMutate: async (request: ChangeDepartmentActivityRequest) => {
+			await queryClient.cancelQueries({
+				queryKey: [departmentsApi.baseKey],
+			});
+
+			const snapshots = optimisticallyUpdateDepartmentActivity(
+				queryClient,
+				request,
+			);
+
+			return { snapshots };
+		},
+		onError: (error, _request, context) => {
+			if (context) {
+				restoreDepartmentQueries(queryClient, context.snapshots);
+			}
+
+			if (error instanceof EnvelopeError) {
+				toast.error(error.allMessages);
+				return;
+			}
+			toast.error("Ошибка при изменении статуса активности");
+		},
+		onSettled: () =>
+			queryClient.invalidateQueries({
+				queryKey: [departmentsApi.baseKey],
+			}),
+	});
+
+	return {
+		toggleDepartmentActivity: mutation.mutate,
+		isPending: mutation.isPending,
+	};
+}

--- a/frontend/src/features/toggle-department-activity/ui/toggle-department-activity.test.tsx
+++ b/frontend/src/features/toggle-department-activity/ui/toggle-department-activity.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ToggleDepartmentActivity } from "./toggle-department-activity";
+
+const mocks = vi.hoisted(() => ({
+	toggleDepartmentActivity: vi.fn(),
+	isPending: false,
+}));
+
+vi.mock("../model/use-toggle-department-activity", () => ({
+	useToggleDepartmentActivity: () => ({
+		toggleDepartmentActivity: mocks.toggleDepartmentActivity,
+		isPending: mocks.isPending,
+	}),
+}));
+
+const department = {
+	id: "department-id",
+	name: "Разработка",
+	identifier: "development",
+	parentId: null,
+	isActive: true,
+	depth: 0,
+	hasChildren: false,
+	path: "development",
+};
+
+describe("ToggleDepartmentActivity", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.isPending = false;
+	});
+
+	it("sends the explicitly selected activity state", async () => {
+		const user = userEvent.setup();
+		render(<ToggleDepartmentActivity department={department} />);
+
+		const activitySwitch = screen.getByRole("switch", { name: "Активно" });
+		expect(activitySwitch).toBeChecked();
+
+		await user.click(activitySwitch);
+
+		expect(mocks.toggleDepartmentActivity).toHaveBeenCalledWith({
+			departmentId: "department-id",
+			isActive: false,
+		});
+	});
+
+	it("shows pending state and disables repeated interaction", () => {
+		mocks.isPending = true;
+
+		render(<ToggleDepartmentActivity department={department} />);
+
+		expect(screen.getByRole("switch", { name: "Сохранение" })).toBeDisabled();
+	});
+});

--- a/frontend/src/features/toggle-department-activity/ui/toggle-department-activity.tsx
+++ b/frontend/src/features/toggle-department-activity/ui/toggle-department-activity.tsx
@@ -1,0 +1,50 @@
+import type { DepartmentTreeDto } from "@/entities/departments";
+import { Label } from "@/shared/components/ui/label";
+import { Switch } from "@/shared/components/ui/switch";
+import { cn } from "@/shared/lib/utils";
+import { LoaderCircle } from "lucide-react";
+import { useToggleDepartmentActivity } from "../model/use-toggle-department-activity";
+
+type Props = {
+	department: DepartmentTreeDto;
+};
+
+export function ToggleDepartmentActivity({ department }: Props) {
+	const { toggleDepartmentActivity, isPending } = useToggleDepartmentActivity();
+	const switchId = `department-activity-${department.id}`;
+	const statusLabel = department.isActive ? "Активно" : "Неактивно";
+
+	return (
+		<div className="flex min-w-32 items-center justify-end gap-2">
+			<Switch
+				id={switchId}
+				checked={department.isActive}
+				disabled={isPending}
+				onCheckedChange={(isActive) =>
+					toggleDepartmentActivity({ departmentId: department.id, isActive })
+				}
+			/>
+			<Label
+				htmlFor={switchId}
+				className={cn(
+					"flex w-20 items-center gap-1.5 text-xs font-medium",
+					department.isActive ? "text-emerald-700" : "text-muted-foreground",
+				)}
+				aria-live="polite"
+			>
+				{isPending ? (
+					<LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
+				) : (
+					<span
+						className={cn(
+							"size-2 rounded-full",
+							department.isActive ? "bg-emerald-500" : "bg-muted-foreground/60",
+						)}
+						aria-hidden="true"
+					/>
+				)}
+				{isPending ? "Сохранение" : statusLabel}
+			</Label>
+		</div>
+	);
+}

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -1,2 +1,8 @@
+export { apiClient } from "./axios-instance";
+export { envelopeInfinityQueryOptions } from "./envelops";
+export type { Envelope, PaginationEnvelope } from "./envelops";
 export { EnvelopeError, isEnvelopeError } from "./errors";
+export type { InfinityScrollRequest } from "./infinity-scroll-request";
+export { PAGE_SIZE } from "./pagination-request";
+export type { PaginationRequest } from "./pagination-request";
 export { queryClient } from "./query-client";

--- a/frontend/src/shared/components/ui/switch.tsx
+++ b/frontend/src/shared/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import * as React from "react";
+import { Switch as SwitchPrimitive } from "radix-ui";
+
+import { cn } from "@/shared/lib/utils";
+
+function Switch({
+	className,
+	size = "default",
+	...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+	size?: "sm" | "default";
+}) {
+	return (
+		<SwitchPrimitive.Root
+			data-slot="switch"
+			data-size={size}
+			className={cn(
+				"peer group/switch focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 relative inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none group-has-[:focus-visible]/field-label:border-transparent group-has-[:focus-visible]/field-label:ring-0 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:ring-3 aria-invalid:ring-3 data-disabled:cursor-not-allowed data-disabled:opacity-50 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px]",
+				className,
+			)}
+			{...props}
+		>
+			<SwitchPrimitive.Thumb
+				data-slot="switch-thumb"
+				className="bg-background dark:data-checked:bg-primary-foreground dark:data-unchecked:bg-foreground pointer-events-none block rounded-full ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0"
+			/>
+		</SwitchPrimitive.Root>
+	);
+}
+
+export { Switch };

--- a/frontend/src/shared/hooks/index.ts
+++ b/frontend/src/shared/hooks/index.ts
@@ -1,0 +1,3 @@
+export { useArchiveView } from "./use-archive-view";
+export type { ArchiveView } from "./use-archive-view";
+export { useCursorRef } from "./use-cursor-ref";

--- a/frontend/src/shared/model/index.ts
+++ b/frontend/src/shared/model/index.ts
@@ -1,0 +1,6 @@
+export { activeFilterOptions, sortDirectionOptions } from "./filter-options";
+export type {
+	ActiveFilter,
+	FilterOption,
+	SortDirectionFilter,
+} from "./filter-types";

--- a/frontend/src/widgets/department-positions/ui/department-positions.tsx
+++ b/frontend/src/widgets/department-positions/ui/department-positions.tsx
@@ -1,4 +1,5 @@
 import { DepartmentTreeRootsList } from "@/features/department-tree";
+import { ToggleDepartmentActivity } from "@/features/toggle-department-activity";
 import { DepartmentPositionsList } from "./department-positions-list";
 import { MoveDepartmentAction } from "./move-department-action";
 
@@ -7,7 +8,10 @@ export function DepartmentPositions() {
 		<div className="grid h-full min-h-0 grid-cols-2 gap-6">
 			<DepartmentTreeRootsList
 				renderActions={(department) => (
-					<MoveDepartmentAction department={department} />
+					<div className="flex shrink-0 items-center gap-1 border-l pl-3">
+						<ToggleDepartmentActivity department={department} />
+						<MoveDepartmentAction department={department} />
+					</div>
 				)}
 			/>
 			<DepartmentPositionsList />

--- a/frontend/src/widgets/department-positions/ui/move-department-action.test.tsx
+++ b/frontend/src/widgets/department-positions/ui/move-department-action.test.tsx
@@ -1,0 +1,35 @@
+import { TooltipProvider } from "@/shared/components/ui/tooltip";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MoveDepartmentAction } from "./move-department-action";
+
+vi.mock("./move-department-dialog", () => ({
+	MoveDepartmentDialog: () => null,
+}));
+
+const department = {
+	id: "department-id",
+	name: "Разработка",
+	identifier: "development",
+	parentId: null,
+	isActive: false,
+	depth: 0,
+	hasChildren: false,
+	path: "development",
+};
+
+describe("MoveDepartmentAction", () => {
+	it("disables move actions for an inactive department", () => {
+		render(
+			<TooltipProvider>
+				<MoveDepartmentAction department={department} />
+			</TooltipProvider>,
+		);
+
+		expect(
+			screen.getByRole("button", {
+				name: "Перенос подразделения Разработка недоступен: сначала активируйте подразделение",
+			}),
+		).toBeDisabled();
+	});
+});

--- a/frontend/src/widgets/department-positions/ui/move-department-action.tsx
+++ b/frontend/src/widgets/department-positions/ui/move-department-action.tsx
@@ -9,6 +9,11 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/shared/components/ui/dropdown-menu";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/shared/components/ui/tooltip";
 import { EllipsisVertical, MoveRight } from "lucide-react";
 import { useState } from "react";
 import { MoveDepartmentDialog } from "./move-department-dialog";
@@ -19,20 +24,43 @@ type Props = {
 
 export function MoveDepartmentAction({ department }: Props) {
 	const [open, setOpen] = useState(false);
+	const canMove = department.isActive;
+
+	const menuTrigger = (
+		<DropdownMenuTrigger asChild>
+			<Button
+				type="button"
+				variant="ghost"
+				size="icon"
+				disabled={!canMove}
+				aria-label={
+					canMove
+						? `Действия подразделения ${department.name}`
+						: `Перенос подразделения ${department.name} недоступен: сначала активируйте подразделение`
+				}
+			>
+				<EllipsisVertical />
+			</Button>
+		</DropdownMenuTrigger>
+	);
 
 	return (
 		<>
 			<DropdownMenu>
-				<DropdownMenuTrigger asChild>
-					<Button
-						type="button"
-						variant="ghost"
-						size="icon"
-						aria-label={`Действия подразделения ${department.name}`}
-					>
-						<EllipsisVertical />
-					</Button>
-				</DropdownMenuTrigger>
+				{canMove ? (
+					menuTrigger
+				) : (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<span className="inline-flex" tabIndex={0}>
+								{menuTrigger}
+							</span>
+						</TooltipTrigger>
+						<TooltipContent side="top">
+							Сначала активируйте подразделение
+						</TooltipContent>
+					</Tooltip>
+				)}
 				<DropdownMenuContent side="right" className="w-auto">
 					<DropdownMenuGroup>
 						<DropdownMenuItem onSelect={() => setOpen(true)}>

--- a/frontend/src/widgets/departments/ui/archived-department-list.tsx
+++ b/frontend/src/widgets/departments/ui/archived-department-list.tsx
@@ -22,6 +22,7 @@ export function ArchivedDepartmentList() {
 	} = useInfiniteDepartmentsList({
 		request: {
 			isActive: false,
+			isArchived: true,
 			search: debouncedSearch,
 		},
 	});

--- a/frontend/src/widgets/departments/ui/department-view-switch.tsx
+++ b/frontend/src/widgets/departments/ui/department-view-switch.tsx
@@ -1,0 +1,34 @@
+import { Button } from "@/shared/components/ui/button";
+import type { ArchiveView } from "@/shared/hooks";
+
+type Props = {
+	value: ArchiveView;
+	onValueChange: (value: ArchiveView) => void;
+};
+
+export function DepartmentViewSwitch({ value, onValueChange }: Props) {
+	return (
+		<div
+			role="group"
+			className="bg-muted flex justify-end gap-2 rounded-2xl border p-2"
+			aria-label="Режим отображения подразделений"
+		>
+			<Button
+				type="button"
+				aria-pressed={value === "active"}
+				variant={value === "active" ? "default" : "outline"}
+				onClick={() => onValueChange("active")}
+			>
+				Структура
+			</Button>
+			<Button
+				type="button"
+				aria-pressed={value === "archived"}
+				variant={value === "archived" ? "default" : "outline"}
+				onClick={() => onValueChange("archived")}
+			>
+				Удалённые
+			</Button>
+		</div>
+	);
+}

--- a/frontend/src/widgets/departments/ui/department-view.tsx
+++ b/frontend/src/widgets/departments/ui/department-view.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { ArchiveViewSwitch } from "@/shared/components/archive-view-switch";
-import { useArchiveView } from "@/shared/hooks/use-archive-view";
-import { ArchivedDepartmentList } from "./archived-department-list";
+import { useArchiveView } from "@/shared/hooks";
 import { DepartmentPositions } from "@/widgets/department-positions";
+import { ArchivedDepartmentList } from "./archived-department-list";
+import { DepartmentViewSwitch } from "./department-view-switch";
 
 export function DepartmentView() {
 	const { view, setView } = useArchiveView();
@@ -19,11 +19,7 @@ export function DepartmentView() {
 							: "Удалённые отделы"}
 					</p>
 				</div>
-				<ArchiveViewSwitch
-					value={view}
-					onValueChange={setView}
-					title="Режим отображения отделов"
-				/>
+				<DepartmentViewSwitch value={view} onValueChange={setView} />
 			</div>
 
 			<div className="min-h-0 flex-1 overflow-y-auto">

--- a/frontend/src/widgets/locations-list/ui/infinite-locations-list.tsx
+++ b/frontend/src/widgets/locations-list/ui/infinite-locations-list.tsx
@@ -8,9 +8,8 @@ import {
 	SelectedDepartment,
 } from "@/features/select-department";
 import { UpdateLocationDialog } from "@/features/update-location";
-import { ArchiveViewSwitch } from "@/shared/components/archive-view-switch";
 import { Spinner } from "@/shared/components/ui/spinner";
-import { useArchiveView } from "@/shared/hooks/use-archive-view";
+import { useArchiveView } from "@/shared/hooks";
 import { ListEmpty } from "@/shared/ui/list-empty";
 import { ListError } from "@/shared/ui/list-error";
 import { useState } from "react";
@@ -22,6 +21,7 @@ import {
 	useLocationSelectedDepartments,
 } from "../model/location-list-store";
 import { LocationFilters } from "./location-filters";
+import { LocationArchiveViewSwitch } from "./location-archive-view-switch";
 
 const LOCATIONS_DEPARTMENT_SELECT_STATE_ID = "locations-department-select";
 
@@ -86,11 +86,7 @@ export function InfiniteLocationsList() {
 					</p>
 				</div>
 
-				<ArchiveViewSwitch
-					value={view}
-					onValueChange={setView}
-					title="Режим отображения локаций"
-				/>
+				<LocationArchiveViewSwitch value={view} onValueChange={setView} />
 			</div>
 
 			<LocationFilters />

--- a/frontend/src/widgets/locations-list/ui/location-archive-view-switch.tsx
+++ b/frontend/src/widgets/locations-list/ui/location-archive-view-switch.tsx
@@ -1,18 +1,17 @@
 import { Button } from "@/shared/components/ui/button";
-import { ArchiveView } from "@/shared/hooks/use-archive-view";
+import type { ArchiveView } from "@/shared/hooks";
 
 type Props = {
 	value: ArchiveView;
 	onValueChange: (value: ArchiveView) => void;
-	title?: string;
 };
 
-export function ArchiveViewSwitch({ value, onValueChange, title }: Props) {
+export function LocationArchiveViewSwitch({ value, onValueChange }: Props) {
 	return (
 		<div
 			role="group"
 			className="bg-muted flex justify-end gap-2 rounded-2xl border p-2"
-			title={title ?? "Режим отображения"}
+			aria-label="Режим отображения локаций"
 		>
 			<Button
 				type="button"


### PR DESCRIPTION
Разделяет активность и архив, запрещает деактивацию при активных потомках и синхронизирует дерево и списки через optimistic update с rollback.

Closes #91